### PR TITLE
Fix Issue #19: Incorrect path was used for root file system

### DIFF
--- a/ki/functional.py
+++ b/ki/functional.py
@@ -42,7 +42,6 @@ from ki.types import (
     PathCreationCollisionError,
 )
 
-FS_ROOT = Path("/")
 SPINNER = "bouncingBall"
 HALO_ENABLED = True
 if "KITEST" in os.environ and os.environ["KITEST"] == "1":
@@ -76,6 +75,13 @@ def copytree(source: ExtantDir, target: NoFile) -> ExtantDir:
 def cwd() -> ExtantDir:
     """Call Path.cwd()."""
     return ExtantDir(Path.cwd().resolve())
+
+
+def is_root(path: ExtantDir):
+    # Check if 'path' is a root directory (e.g., '/' on Unix or 'C:\' on Windows).
+    # Symlinks are resolved before checking.
+    path = path.resolve() # Resolve symlinks.
+    return len(path.parents) == 0
 
 
 @functools.cache
@@ -176,8 +182,8 @@ def parent(path: Union[ExtantFile, ExtantDir]) -> ExtantDir:
     Get the parent of a path that exists.  If the path points to the filesystem
     root, we return itself.
     """
-    if path.resolve() == FS_ROOT:
-        return ExtantDir(FS_ROOT.resolve())
+    if is_root(path):
+        return ExtantDir(path.resolve())
     return ExtantDir(path.parent)
 
 

--- a/ki/maybes.py
+++ b/ki/maybes.py
@@ -37,7 +37,6 @@ from ki.types import (
     GitHeadRefNotFoundError,
     AnkiAlreadyOpenError,
 )
-from ki.functional import FS_ROOT
 
 KI = ".ki"
 GIT = ".git"
@@ -188,16 +187,13 @@ def kirepo(cwd: ExtantDir) -> KiRepo:
     """Get the containing ki repository of `path`."""
     current = cwd
 
-    # Note that `current` is an `ExtantDir` but `FS_ROOT` is a `Path`.
-    # We can make this comparison because both are instances of `Path` and
-    # `Path` implements the `==` operator nicely.
-    while current != FS_ROOT:
+    while not F.is_root(current):
         ki_dir = F.test(current / KI)
         if isinstance(ki_dir, ExtantDir):
             break
         current = F.parent(current)
 
-    if current == FS_ROOT:
+    if F.is_root(current):
         raise NotKiRepoError()
 
     # Root directory and ki directory of repo now guaranteed to exist.


### PR DESCRIPTION
Create a cross-platform method for checking if a directory is the root directory of a file system.

I couldn't check that all of the tests passed because most of them failed from the get-go, but _more_ tests pass on Windows than before.