### PR TITLE
WIP: Add reimplementation of post-clone-failure cleanup.

### DIFF
--- a/ki/__init__.py
+++ b/ki/__init__.py
@@ -963,7 +963,8 @@ def get_media_files(
 
     # Faster version.
     _, _, files = F.shallow_walk(media_dir)
-    for fname in files:
+    fnames: List[Path] = [Path(file.name) for file in files]
+    for fname in fnames:
 
         # Notetype template media files are *always* prefixed by underscores.
         if str(fname).startswith("_"):

--- a/ki/__init__.py
+++ b/ki/__init__.py
@@ -1401,14 +1401,16 @@ def tidy_html_recursively(root: ExtantDir, silent: bool) -> None:
 
 
 @beartype
-def get_target(cwd: ExtantDir, col_file: ExtantFile, directory: str) -> EmptyDir:
+def get_target(cwd: ExtantDir, col_file: ExtantFile, directory: str) -> Tuple[EmptyDir, bool]:
     """Create default target directory."""
     path = F.test(Path(directory) if directory != "" else cwd / col_file.stem)
+    new: bool = True
     if isinstance(path, NoPath):
         path.mkdir(parents=True)
-        return M.emptydir(path)
+        return M.emptydir(path), new
     if isinstance(path, EmptyDir):
-        return path
+        new = False
+        return path, new
     raise TargetExistsError(path)
 
 
@@ -1593,12 +1595,30 @@ def clone(collection: str, directory: str = "") -> None:
     echo("Cloning.")
     col_file: ExtantFile = M.xfile(Path(collection))
 
+    @beartype
+    def cleanup(targetdir: ExtantDir, new: bool) -> Union[EmptyDir, NoPath]:
+        """Cleans up after failed clone operations."""
+        if new:
+            return F.rmtree(targetdir)
+        _, dirs, files = F.shallow_walk(targetdir)
+        for directory in dirs:
+            F.rmtree(directory)
+        for file in files:
+            os.remove(file)
+        return F.test(targetdir)
+
     # Write all files to `targetdir`, and instantiate a `KiRepo` object.
-    targetdir: EmptyDir = get_target(F.cwd(), col_file, directory)
-    _, _ = _clone(col_file, targetdir, msg="Initial commit", silent=False)
-    kirepo: KiRepo = M.kirepo(targetdir)
-    F.write(kirepo.last_push_file, kirepo.repo.head.commit.hexsha)
-    echo("Done.")
+    targetdir: EmptyDir
+    new: bool
+    targetdir, new = get_target(F.cwd(), col_file, directory)
+    try:
+        _, _ = _clone(col_file, targetdir, msg="Initial commit", silent=False)
+        kirepo: KiRepo = M.kirepo(targetdir)
+        F.write(kirepo.last_push_file, kirepo.repo.head.commit.hexsha)
+        echo("Done.")
+    except Exception as err:
+        cleanup(targetdir, new)
+        raise err
 
     if PROFILE:
         profiler.stop()

--- a/ki/functional.py
+++ b/ki/functional.py
@@ -85,9 +85,10 @@ def shallow_walk(
 ) -> Tuple[ExtantDir, List[ExtantDir], List[ExtantFile]]:
     """Walk only the top-level directory with `os.walk()`."""
     root, dirs, files = next(os.walk(directory))
-    dirs = [ExtantDir(d) for d in dirs]
-    files = [ExtantFile(f) for f in files]
-    return ExtantDir(root), dirs, files
+    root = ExtantDir(root)
+    dirs = [ExtantDir(root / d) for d in dirs]
+    files = [ExtantFile(root / f) for f in files]
+    return root, dirs, files
 
 
 @beartype

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -413,8 +413,6 @@ def test_clone_errors_when_directory_is_populated():
             clone(runner, col_file)
 
 
-# TODO: This must be re-implemented.
-@pytest.mark.xfail
 def test_clone_cleans_up_on_error():
     """Does it clean up on nontrivial errors?"""
     col_file = get_html_col_file()
@@ -426,10 +424,31 @@ def test_clone_cleans_up_on_error():
         shutil.rmtree(HTML_REPODIR)
         old_path = os.environ["PATH"]
         try:
-            with pytest.raises(FileNotFoundError):
+            with pytest.raises(FileNotFoundError) as err:
                 os.environ["PATH"] = ""
                 clone(runner, col_file)
+            logger.debug(err)
             assert not os.path.isdir(HTML_REPODIR)
+        finally:
+            os.environ["PATH"] = old_path
+
+
+def test_clone_cleans_up_preserves_directories_that_exist_a_priori():
+    """Does clone not delete targetdirs that already existed?"""
+    col_file = get_html_col_file()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+
+        os.mkdir(HTML_REPODIR)
+        assert os.path.isdir(HTML_REPODIR)
+        old_path = os.environ["PATH"]
+        try:
+            with pytest.raises(FileNotFoundError) as err:
+                os.environ["PATH"] = ""
+                clone(runner, col_file)
+            logger.debug(err)
+            assert os.path.isdir(HTML_REPODIR)
+            assert len(os.listdir(HTML_REPODIR)) == 0
         finally:
             os.environ["PATH"] = old_path
 
@@ -437,11 +456,6 @@ def test_clone_cleans_up_on_error():
 # TODO: Consider writing new `Exception` subclasses that print a slightly
 # prettier message, informing the user of how to install the relevant missing
 # dependency.
-#
-# TODO: This test now fails, which we expect, since the code that does
-# auto-cleanup on clone fail has been removed. This must be added back in when
-# we do error-handling.
-@pytest.mark.xfail
 def test_clone_displays_nice_errors_for_missing_dependencies():
     """Does it tell the user what to install?"""
     col_file = get_html_col_file()

--- a/tests/test_ki.py
+++ b/tests/test_ki.py
@@ -1617,3 +1617,16 @@ def test_get_media_files_finds_notetype_media():
         media_files = sorted(list(media_files))
         von_neumann: ExtantFile = media_files[1]
         assert "_vonNeumann" in str(von_neumann)
+
+
+def test_shallow_walk_returns_extant_paths():
+    """Shallow walk should only return paths that actually exist."""
+    tmpdir = F.mkdtemp()
+    (tmpdir / "file").touch()
+    (tmpdir / "directory").mkdir()
+    root, dirs, files = F.shallow_walk(tmpdir)
+    assert os.path.isdir(root)
+    for d in dirs:
+        assert os.path.isdir(d)
+    for file in files:
+        assert os.path.isfile(file)


### PR DESCRIPTION
Fixes #29 and also fixes a previously undetected bug in `F.shallow_walk()`.

Add new return value `new: bool` to `get_target()`.
Add function `cleanup()`.
Fix bug in `shallow_walk()` where returned paths did not exist.
The above may have caused a regression in the other place where
`shallow_walk()` is called.
Un-xfail `test_clone_cleans_up_on_error()`.
Add `test_clone_cleans_up_preserves_directories_that_exist_a_priori()`.
Un-xfail `test_clone_displays_nice_errors_for_missing_dependencies()`.
Add test `test_shallow_walk_returns_extant_paths()`.