### PR TITLE
Add better message for `DiffTargetFileNotFoundWarning`, indicating what the user should do when they accidentally `git add` a subrepository

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install tidy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           git config --global user.email "ki@example.com"
           git config --global user.name "Ki GithubActions"
+          git --version
       - name: Install dependencies
         run: |
           pip install pytest wheel

--- a/ki/types.py
+++ b/ki/types.py
@@ -593,8 +593,15 @@ class DiffTargetFileNotFoundWarning(Warning):
     @beartype
     def __init__(self, path: Path):
         top = f"Diff target file not found: '{path}'"
-        msg = """
-        Unexpected: this may indicate a bug in ki. The caller prevents this
+        msg1 = """
+        Unexpected: this sometimes happens when a git repository is copied into
+        a subdirectory of a ki repository, and then added with 'git add'
+        instead of being added as a git submodule with 'git submodule add'. If
+        git displayed a warning on a recent 'git add' command, refer to the
+        hints within that warning.
+        """
+        msg2 = """
+        Otherwise, this may indicate a bug in ki.  The caller prevents this
         warning from being instantiated unless the git change type is one of
         'ADDED', 'MODIFIED', or 'RENAMED'. In all cases, the file being diffed
         should be extant in the target commit of the repository.  However, we
@@ -602,7 +609,7 @@ class DiffTargetFileNotFoundWarning(Warning):
         interrupting the execution of a 'push()' call where it is not strictly
         necessary.
         """
-        super().__init__(f"{top}\n{errwrap(msg)}")
+        super().__init__(f"{top}\n\n{errwrap(msg1)}\n\n{errwrap(msg2)}")
 
 
 class MissingMediaFileWarning(Warning):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,7 +92,6 @@ EDITED: SampleCollection = get_test_collection("edited")
 # CLI
 
 
-@pytest.mark.skip
 def test_bad_command_is_bad():
     """Typos should result in errors."""
     result = invoke(ki.ki, ["clome"])
@@ -100,7 +99,6 @@ def test_bad_command_is_bad():
     assert "Error: No such command 'clome'." in result.output
 
 
-@pytest.mark.skip
 def test_runas_module():
     """Can this package be run as a Python module?"""
     command = "python -m ki --help"
@@ -108,14 +106,12 @@ def test_runas_module():
     assert completed.returncode == 0
 
 
-@pytest.mark.skip
 def test_entrypoint():
     """Is entrypoint script installed? (setup.py)"""
     result = invoke(ki.ki, ["--help"])
     assert result.exit_code == 0
 
 
-@pytest.mark.skip
 def test_version():
     """Does --version display information as expected?"""
     expected_version = version("ki")
@@ -125,7 +121,6 @@ def test_version():
     assert result.exit_code == 0
 
 
-@pytest.mark.skip
 def test_command_availability():
     """Are commands available?"""
     results = []
@@ -136,7 +131,6 @@ def test_command_availability():
         assert result.exit_code == 0
 
 
-@pytest.mark.skip
 def test_cli():
     """Does CLI stop execution w/o a command argument?"""
     with pytest.raises(SystemExit):
@@ -148,7 +142,6 @@ def test_cli():
 
 
 @beartype
-@pytest.mark.skip
 def test_fails_without_ki_subdirectory(tmp_path: Path):
     """Do pull and push know whether they're in a ki-generated git repo?"""
     runner = CliRunner()
@@ -163,7 +156,6 @@ def test_fails_without_ki_subdirectory(tmp_path: Path):
 
 
 @beartype
-@pytest.mark.skip
 def test_computes_and_stores_md5sum(tmp_path: Path):
     """Does ki add new hash to `.ki/hashes`?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -201,7 +193,6 @@ def test_computes_and_stores_md5sum(tmp_path: Path):
             assert f"199216c39eeabe23a1da016a99ffd3e2  {ORIGINAL.filename}" in hashes
 
 
-@pytest.mark.skip
 def test_no_op_pull_push_cycle_is_idempotent():
     """Do pull/push not misbehave if you keep doing both?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -227,7 +218,6 @@ def test_no_op_pull_push_cycle_is_idempotent():
         push(runner)
 
 
-@pytest.mark.skip
 def test_output(tmp_path: Path):
     """Does it print nice things?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -267,7 +257,6 @@ def test_output(tmp_path: Path):
 # CLONE
 
 
-@pytest.mark.skip
 def test_clone_fails_if_collection_doesnt_exist():
     """Does ki clone only if `.anki2` file exists?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -281,7 +270,6 @@ def test_clone_fails_if_collection_doesnt_exist():
         assert not os.path.isdir(ORIGINAL.repodir)
 
 
-@pytest.mark.skip
 def test_clone_fails_if_collection_is_already_open():
     """Does ki print a nice error message when Anki is accidentally left open?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -293,7 +281,6 @@ def test_clone_fails_if_collection_is_already_open():
             clone(runner, ORIGINAL.col_file)
 
 
-@pytest.mark.skip
 def test_clone_creates_directory():
     """Does it create the directory?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -307,7 +294,6 @@ def test_clone_creates_directory():
 
 
 @beartype
-@pytest.mark.skip
 def test_clone_displays_errors_from_creation_of_kirepo_metadata(mocker: MockerFixture):
     """Do errors get displayed nicely?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -323,7 +309,6 @@ def test_clone_displays_errors_from_creation_of_kirepo_metadata(mocker: MockerFi
 
 
 @beartype
-@pytest.mark.skip
 def test_clone_displays_errors_from_loading_kirepo_at_end(mocker: MockerFixture):
     """Do errors get propagated in the places we expect?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -374,7 +359,6 @@ def test_clone_displays_errors_from_loading_kirepo_at_end(mocker: MockerFixture)
             clone(runner, ORIGINAL.col_file)
 
 
-@pytest.mark.skip
 def test_clone_handles_html():
     """Does it tidy html and stuff?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -394,7 +378,6 @@ def test_clone_handles_html():
         assert snippet in contents
 
 
-@pytest.mark.skip
 def test_clone_tidying_only_breaks_lines_for_fields_containing_html():
     """Does it tidy html and stuff?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -415,7 +398,6 @@ def test_clone_tidying_only_breaks_lines_for_fields_containing_html():
         )
 
 
-@pytest.mark.skip
 def test_clone_errors_when_directory_is_populated():
     """Does it disallow overwrites?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -434,7 +416,6 @@ def test_clone_errors_when_directory_is_populated():
             clone(runner, ORIGINAL.col_file)
 
 
-@pytest.mark.skip
 def test_clone_cleans_up_on_error():
     """Does it clean up on nontrivial errors?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -455,7 +436,6 @@ def test_clone_cleans_up_on_error():
             os.environ["PATH"] = old_path
 
 
-@pytest.mark.skip
 def test_clone_cleans_up_preserves_directories_that_exist_a_priori():
     """Does clone not delete targetdirs that already existed?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -476,7 +456,6 @@ def test_clone_cleans_up_preserves_directories_that_exist_a_priori():
             os.environ["PATH"] = old_path
 
 
-@pytest.mark.skip
 def test_clone_displays_nice_errors_for_missing_dependencies():
     """Does it tell the user what to install?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -512,7 +491,6 @@ def test_clone_displays_nice_errors_for_missing_dependencies():
             os.environ["PATH"] = old_path
 
 
-@pytest.mark.skip
 def test_clone_succeeds_when_directory_exists_but_is_empty():
     """Does it clone into empty directories?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -524,7 +502,6 @@ def test_clone_succeeds_when_directory_exists_but_is_empty():
         clone(runner, ORIGINAL.col_file)
 
 
-@pytest.mark.skip
 def test_clone_generates_expected_notes():
     """Do generated note files match content of an example collection?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -546,7 +523,6 @@ def test_clone_generates_expected_notes():
         assert cloned_md5 == true_md5
 
 
-@pytest.mark.skip
 def test_clone_generates_deck_tree_correctly():
     """Does generated FS tree match example collection?"""
     MULTIDECK: SampleCollection = get_test_collection("multideck")
@@ -571,7 +547,6 @@ def test_clone_generates_deck_tree_correctly():
         assert cloned_md5 == true_md5
 
 
-@pytest.mark.skip
 def test_clone_generates_ki_subdirectory():
     """Does clone command generate .ki/ directory?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -586,7 +561,6 @@ def test_clone_generates_ki_subdirectory():
         assert os.path.isdir(kidir)
 
 
-@pytest.mark.skip
 def test_cloned_collection_is_git_repository():
     """Does clone run `git init` and stuff?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -599,7 +573,6 @@ def test_cloned_collection_is_git_repository():
         assert is_git_repo(ORIGINAL.repodir)
 
 
-@pytest.mark.skip
 def test_clone_commits_directory_contents():
     """Does clone leave user with an up-to-date repo?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -621,7 +594,6 @@ def test_clone_commits_directory_contents():
         assert len(commits) == 1
 
 
-@pytest.mark.skip
 def test_clone_leaves_collection_file_unchanged():
     """Does clone leave the collection alone?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -636,7 +608,6 @@ def test_clone_leaves_collection_file_unchanged():
         assert original_md5 == updated_md5
 
 
-@pytest.mark.skip
 def test_clone_directory_argument_works():
     """Does clone obey the target directory argument?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -653,7 +624,6 @@ def test_clone_directory_argument_works():
         assert os.path.isdir(target)
 
 
-@pytest.mark.skip
 def test_clone_writes_media_files():
     """Does clone copy media files from the media directory into 'MEDIA'?"""
     MEDIACOL: SampleCollection = get_test_collection("media")
@@ -666,7 +636,6 @@ def test_clone_writes_media_files():
         assert audio_path.is_file()
 
 
-@pytest.mark.skip
 def test_clone_handles_cards_from_a_single_note_in_distinct_decks(tmp_path: Path):
     SPLIT: SampleCollection = get_test_collection("split")
     runner = CliRunner()
@@ -680,7 +649,6 @@ def test_clone_handles_cards_from_a_single_note_in_distinct_decks(tmp_path: Path
 # PULL
 
 
-@pytest.mark.skip
 def test_pull_fails_if_collection_no_longer_exists():
     """Does ki pull only if `.anki2` file exists?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -697,7 +665,6 @@ def test_pull_fails_if_collection_no_longer_exists():
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_fails_if_collection_file_is_corrupted():
     """Does `pull()` fail gracefully when the collection file is bad?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -715,7 +682,6 @@ def test_pull_fails_if_collection_file_is_corrupted():
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_writes_changes_correctly():
     """Does ki get the changes from modified collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -735,7 +701,6 @@ def test_pull_writes_changes_correctly():
         assert os.path.isfile(NOTE_1)
 
 
-@pytest.mark.skip
 def test_pull_unchanged_collection_is_no_op():
     """Does ki remove remote before quitting?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -755,7 +720,6 @@ def test_pull_unchanged_collection_is_no_op():
         assert orig_hash == new_hash
 
 
-@pytest.mark.skip
 def test_pull_avoids_unnecessary_merge_conflicts():
     """Does ki prevent gratuitous merge conflicts?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -775,7 +739,6 @@ def test_pull_avoids_unnecessary_merge_conflicts():
         assert "Automatic merge failed; fix" not in out
 
 
-@pytest.mark.skip
 def test_pull_still_works_from_subdirectories():
     """Does pull still work if you're farther down in the directory tree than the repo route?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -794,7 +757,6 @@ def test_pull_still_works_from_subdirectories():
         pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_displays_errors_from_repo_ref():
     """Does 'pull()' return early when the last push commit ref is bad?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -815,7 +777,6 @@ def test_pull_displays_errors_from_repo_ref():
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_displays_errors_from_clone_helper(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -836,7 +797,6 @@ def test_pull_displays_errors_from_clone_helper(mocker: MockerFixture):
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_handles_unexpectedly_changed_checksums(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -855,7 +815,6 @@ def test_pull_handles_unexpectedly_changed_checksums(mocker: MockerFixture):
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_displays_errors_from_repo_initialization(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -876,7 +835,6 @@ def test_pull_displays_errors_from_repo_initialization(mocker: MockerFixture):
             pull(runner)
 
 
-@pytest.mark.skip
 def test_pull_preserves_reassigned_note_ids(tmp_path: Path):
     """UNFINISHED!"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -908,7 +866,6 @@ def test_pull_preserves_reassigned_note_ids(tmp_path: Path):
         logger.debug(out)
 
 
-@pytest.mark.skip
 def test_pull_handles_uncommitted_submodule_commits(tmp_path: Path):
     UNCOMMITTED_SM: SampleCollection = get_test_collection(
         "uncommitted_submodule_commits"
@@ -997,7 +954,6 @@ def test_pull_handles_uncommitted_submodule_commits(tmp_path: Path):
         assert expected_this in note_text
 
 
-@pytest.mark.skip
 def test_pull_removes_files_deleted_in_remote(tmp_path: Path):
     ORIGINAL: SampleCollection = get_test_collection("original")
     DELETED: SampleCollection = get_test_collection("deleted")
@@ -1015,7 +971,6 @@ def test_pull_removes_files_deleted_in_remote(tmp_path: Path):
         logger.debug(out)
 
 
-@pytest.mark.skip
 def test_pull_does_not_duplicate_decks_converted_to_subdecks_of_new_top_level_decks(tmp_path: Path):
     BEFORE: SampleCollection = get_test_collection("duplicated_subdeck_before")
     AFTER: SampleCollection = get_test_collection("duplicated_subdeck_after")
@@ -1046,7 +1001,6 @@ def test_pull_does_not_duplicate_decks_converted_to_subdecks_of_new_top_level_de
 # PUSH
 
 
-@pytest.mark.skip
 def test_push_writes_changes_correctly(tmp_path: Path):
     """If there are committed changes, does push change the collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1105,7 +1059,6 @@ def test_push_writes_changes_correctly(tmp_path: Path):
         assert len(new_notes) == 2
 
 
-@pytest.mark.skip
 def test_push_verifies_md5sum():
     """Does ki only push if md5sum matches last pull?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1124,7 +1077,6 @@ def test_push_verifies_md5sum():
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_generates_correct_backup():
     """Does push store a backup identical to old collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1160,7 +1112,6 @@ def test_push_generates_correct_backup():
         assert backup_exists
 
 
-@pytest.mark.skip
 def test_push_doesnt_write_uncommitted_changes():
     """Does push only write changes that have been committed?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1182,7 +1133,6 @@ def test_push_doesnt_write_uncommitted_changes():
         assert len(os.listdir(".ki/backups")) == 0
 
 
-@pytest.mark.skip
 def test_push_doesnt_fail_after_pull():
     """Does push work if we pull and then edit and then push?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1222,7 +1172,6 @@ def test_push_doesnt_fail_after_pull():
         push(runner)
 
 
-@pytest.mark.skip
 def test_no_op_push_is_idempotent():
     """Does push not misbehave if you keep pushing?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1242,7 +1191,6 @@ def test_no_op_push_is_idempotent():
         push(runner)
 
 
-@pytest.mark.skip
 def test_push_deletes_notes():
     """Does push remove deleted notes from collection?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1274,7 +1222,6 @@ def test_push_deletes_notes():
         assert not os.path.isfile(NOTE_0)
 
 
-@pytest.mark.skip
 def test_push_still_works_from_subdirectories():
     """Does push still work if you're farther down in the directory tree than the repo route?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1300,7 +1247,6 @@ def test_push_still_works_from_subdirectories():
         push(runner)
 
 
-@pytest.mark.skip
 def test_push_deletes_added_notes():
     """Does push remove deleted notes added with ki?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1361,7 +1307,6 @@ def test_push_deletes_added_notes():
         assert len(notes) == 2
 
 
-@pytest.mark.skip
 def test_push_generates_correct_title_for_notes():
     """Does push use the truncated sort field as a filename?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1392,7 +1337,6 @@ def test_push_generates_correct_title_for_notes():
         assert "r.md" in notes
 
 
-@pytest.mark.skip
 def test_push_displays_informative_error_when_last_push_file_is_missing():
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1411,7 +1355,6 @@ def test_push_displays_informative_error_when_last_push_file_is_missing():
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_honors_ignore_patterns():
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1451,7 +1394,6 @@ def test_push_honors_ignore_patterns():
         assert "Warning: not Anki note" in out
 
 
-@pytest.mark.skip
 def test_push_displays_errors_from_head_ref_maybes(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1473,7 +1415,6 @@ def test_push_displays_errors_from_head_ref_maybes(mocker: MockerFixture):
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_displays_errors_from_head_repo_ref(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1497,7 +1438,6 @@ def test_push_displays_errors_from_head_repo_ref(mocker: MockerFixture):
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_model_adding(
     mocker: MockerFixture,
 ):
@@ -1529,7 +1469,6 @@ def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_model_
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_push_flatnote_to_anki(
     mocker: MockerFixture,
 ):
@@ -1563,7 +1502,6 @@ def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_push_f
             logger.debug(out)
 
 
-@pytest.mark.skip
 def test_push_handles_submodules(tmp_path: Path):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1597,7 +1535,6 @@ def test_push_handles_submodules(tmp_path: Path):
         assert "<br>z<br>" in notes[0]["Back"]
 
 
-@pytest.mark.skip
 def test_push_writes_media(tmp_path: Path):
     MEDIACOL: SampleCollection = get_test_collection("media")
     runner = CliRunner()
@@ -1629,7 +1566,6 @@ def test_push_writes_media(tmp_path: Path):
         assert len(check.unused) == 0
 
 
-@pytest.mark.skip
 def test_push_handles_foreign_models(tmp_path: Path):
     """Just check that we don't return an exception from `push()`."""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1647,7 +1583,6 @@ def test_push_handles_foreign_models(tmp_path: Path):
         logger.debug(out)
 
 
-@pytest.mark.skip
 def test_push_fails_if_database_is_locked():
     """Does ki print a nice error message when Anki is accidentally left open?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1667,7 +1602,6 @@ def test_push_fails_if_database_is_locked():
             push(runner)
 
 
-@pytest.mark.skip
 def test_push_is_nontrivial_when_pulled_changes_are_reverted(tmp_path: Path):
     """
     If you push, make changes in Anki, then pull those changes, then undo them
@@ -1727,7 +1661,6 @@ def test_push_is_nontrivial_when_pulled_changes_are_reverted(tmp_path: Path):
         assert "ki push: up to date." not in out
 
 
-@pytest.mark.skip
 def test_push_doesnt_unnecessarily_deduplicate_notetypes():
     """
     Does push refrain from adding a new notetype if the requested notetype
@@ -1792,7 +1725,6 @@ def test_push_doesnt_unnecessarily_deduplicate_notetypes():
         col.close(save=False)
 
 
-@pytest.mark.skip
 def test_push_is_nontrivial_when_pushed_changes_are_reverted_in_repository():
     """
     The following operation should be nontrivial:
@@ -1844,7 +1776,6 @@ def test_push_is_nontrivial_when_pushed_changes_are_reverted_in_repository():
         assert "ki push: up to date." not in out
 
 
-@pytest.mark.skip
 def test_push_changes_deck_for_moved_notes():
     MULTIDECK: SampleCollection = get_test_collection("multideck")
     runner = CliRunner()
@@ -1880,7 +1811,6 @@ def test_push_changes_deck_for_moved_notes():
         assert colnote.deck == "aa::dd"
 
 
-@pytest.mark.skip
 def test_push_is_trivial_for_committed_submodule_contents(tmp_path: Path):
     UNCOMMITTED_SM: SampleCollection = get_test_collection(
         "uncommitted_submodule_commits"
@@ -1942,22 +1872,8 @@ def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_
         shutil.copytree(japanese_gitrepo_path, submodule_name)
 
         repo = git.Repo(".")
-        logger.debug(os.path.abspath("."))
-        p = subprocess.run(["git", "status"], capture_output=True, encoding="UTF-8")
-        logger.debug(p.stdout)
-        logger.debug(p.stderr)
-        p = subprocess.run(["git", "ls-tree", "HEAD"], capture_output=True, encoding="UTF-8")
-        logger.debug(p.stdout)
-        logger.debug(p.stderr)
         p = subprocess.run(["git", "add", "--all"], capture_output=True, encoding="UTF-8")
-        logger.debug(p.stdout)
-        logger.debug(p.stderr)
-        assert "hint" in p.stderr
-        raise RuntimeError
-        out = repo.git.add(all=True)
-        logger.debug(out)
-        repo.index.commit("Add subrepo.")
-
-        out = push(runner)
-        logger.debug(out)
-        assert "'git submodule add'" in out
+        if "warning" in p.stderr:
+            repo.index.commit("Add subrepo.")
+            out = push(runner)
+            assert "'git submodule add'" in out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1853,3 +1853,26 @@ def test_push_is_trivial_for_committed_submodule_contents(tmp_path: Path):
         out = push(runner)
         logger.debug(out)
         assert "ki push: up to date." in out
+
+
+def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_of_submodule():
+    ORIGINAL: SampleCollection = get_test_collection("original")
+    runner = CliRunner()
+    japanese_gitrepo_path = Path(JAPANESE_GITREPO_PATH).resolve()
+    with runner.isolated_filesystem():
+
+        JAPANESE_SUBMODULE_DIRNAME = "japanese-core-2000"
+
+        # Clone collection in cwd.
+        clone(runner, ORIGINAL.col_file)
+        os.chdir(ORIGINAL.repodir)
+
+        # Add a *subrepo* (not submodule).
+        submodule_name = JAPANESE_SUBMODULE_DIRNAME
+        shutil.copytree(japanese_gitrepo_path, submodule_name)
+
+        repo = git.Repo(".")
+        repo.git.add(all=True)
+
+        out = push(runner)
+        assert "'git submodule add'" in out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1943,6 +1943,12 @@ def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_
 
         repo = git.Repo(".")
         logger.debug(os.path.abspath("."))
+        p = subprocess.run(["git", "status"], capture_output=True, encoding="UTF-8")
+        logger.debug(p.stdout)
+        logger.debug(p.stderr)
+        p = subprocess.run(["git", "ls-tree", "HEAD"], capture_output=True, encoding="UTF-8")
+        logger.debug(p.stdout)
+        logger.debug(p.stderr)
         p = subprocess.run(["git", "add", "--all"], capture_output=True, encoding="UTF-8")
         logger.debug(p.stdout)
         logger.debug(p.stderr)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1925,11 +1925,11 @@ def test_push_is_trivial_for_committed_submodule_contents(tmp_path: Path):
         assert "ki push: up to date." in out
 
 
-def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_of_submodule():
+def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_of_submodule(tmp_path: Path):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
     japanese_gitrepo_path = Path(JAPANESE_GITREPO_PATH).resolve()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
 
         JAPANESE_SUBMODULE_DIRNAME = "japanese-core-2000"
 
@@ -1942,7 +1942,14 @@ def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_
         shutil.copytree(japanese_gitrepo_path, submodule_name)
 
         repo = git.Repo(".")
-        repo.git.add(all=True)
+        logger.debug(os.path.abspath("."))
+        p = subprocess.run(["git", "add", "--all"], capture_output=True, encoding="UTF-8")
+        logger.debug(p.stdout)
+        logger.debug(p.stderr)
+        assert "hint" in p.stderr
+        raise RuntimeError
+        out = repo.git.add(all=True)
+        logger.debug(out)
         repo.index.commit("Add subrepo.")
 
         out = push(runner)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,6 +92,7 @@ EDITED: SampleCollection = get_test_collection("edited")
 # CLI
 
 
+@pytest.mark.skip
 def test_bad_command_is_bad():
     """Typos should result in errors."""
     result = invoke(ki.ki, ["clome"])
@@ -99,6 +100,7 @@ def test_bad_command_is_bad():
     assert "Error: No such command 'clome'." in result.output
 
 
+@pytest.mark.skip
 def test_runas_module():
     """Can this package be run as a Python module?"""
     command = "python -m ki --help"
@@ -106,12 +108,14 @@ def test_runas_module():
     assert completed.returncode == 0
 
 
+@pytest.mark.skip
 def test_entrypoint():
     """Is entrypoint script installed? (setup.py)"""
     result = invoke(ki.ki, ["--help"])
     assert result.exit_code == 0
 
 
+@pytest.mark.skip
 def test_version():
     """Does --version display information as expected?"""
     expected_version = version("ki")
@@ -121,6 +125,7 @@ def test_version():
     assert result.exit_code == 0
 
 
+@pytest.mark.skip
 def test_command_availability():
     """Are commands available?"""
     results = []
@@ -131,6 +136,7 @@ def test_command_availability():
         assert result.exit_code == 0
 
 
+@pytest.mark.skip
 def test_cli():
     """Does CLI stop execution w/o a command argument?"""
     with pytest.raises(SystemExit):
@@ -142,6 +148,7 @@ def test_cli():
 
 
 @beartype
+@pytest.mark.skip
 def test_fails_without_ki_subdirectory(tmp_path: Path):
     """Do pull and push know whether they're in a ki-generated git repo?"""
     runner = CliRunner()
@@ -156,6 +163,7 @@ def test_fails_without_ki_subdirectory(tmp_path: Path):
 
 
 @beartype
+@pytest.mark.skip
 def test_computes_and_stores_md5sum(tmp_path: Path):
     """Does ki add new hash to `.ki/hashes`?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -193,6 +201,7 @@ def test_computes_and_stores_md5sum(tmp_path: Path):
             assert f"199216c39eeabe23a1da016a99ffd3e2  {ORIGINAL.filename}" in hashes
 
 
+@pytest.mark.skip
 def test_no_op_pull_push_cycle_is_idempotent():
     """Do pull/push not misbehave if you keep doing both?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -218,6 +227,7 @@ def test_no_op_pull_push_cycle_is_idempotent():
         push(runner)
 
 
+@pytest.mark.skip
 def test_output(tmp_path: Path):
     """Does it print nice things?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -257,6 +267,7 @@ def test_output(tmp_path: Path):
 # CLONE
 
 
+@pytest.mark.skip
 def test_clone_fails_if_collection_doesnt_exist():
     """Does ki clone only if `.anki2` file exists?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -270,6 +281,7 @@ def test_clone_fails_if_collection_doesnt_exist():
         assert not os.path.isdir(ORIGINAL.repodir)
 
 
+@pytest.mark.skip
 def test_clone_fails_if_collection_is_already_open():
     """Does ki print a nice error message when Anki is accidentally left open?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -281,6 +293,7 @@ def test_clone_fails_if_collection_is_already_open():
             clone(runner, ORIGINAL.col_file)
 
 
+@pytest.mark.skip
 def test_clone_creates_directory():
     """Does it create the directory?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -294,6 +307,7 @@ def test_clone_creates_directory():
 
 
 @beartype
+@pytest.mark.skip
 def test_clone_displays_errors_from_creation_of_kirepo_metadata(mocker: MockerFixture):
     """Do errors get displayed nicely?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -309,6 +323,7 @@ def test_clone_displays_errors_from_creation_of_kirepo_metadata(mocker: MockerFi
 
 
 @beartype
+@pytest.mark.skip
 def test_clone_displays_errors_from_loading_kirepo_at_end(mocker: MockerFixture):
     """Do errors get propagated in the places we expect?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -359,6 +374,7 @@ def test_clone_displays_errors_from_loading_kirepo_at_end(mocker: MockerFixture)
             clone(runner, ORIGINAL.col_file)
 
 
+@pytest.mark.skip
 def test_clone_handles_html():
     """Does it tidy html and stuff?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -378,6 +394,7 @@ def test_clone_handles_html():
         assert snippet in contents
 
 
+@pytest.mark.skip
 def test_clone_tidying_only_breaks_lines_for_fields_containing_html():
     """Does it tidy html and stuff?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -398,6 +415,7 @@ def test_clone_tidying_only_breaks_lines_for_fields_containing_html():
         )
 
 
+@pytest.mark.skip
 def test_clone_errors_when_directory_is_populated():
     """Does it disallow overwrites?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -416,6 +434,7 @@ def test_clone_errors_when_directory_is_populated():
             clone(runner, ORIGINAL.col_file)
 
 
+@pytest.mark.skip
 def test_clone_cleans_up_on_error():
     """Does it clean up on nontrivial errors?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -436,6 +455,7 @@ def test_clone_cleans_up_on_error():
             os.environ["PATH"] = old_path
 
 
+@pytest.mark.skip
 def test_clone_cleans_up_preserves_directories_that_exist_a_priori():
     """Does clone not delete targetdirs that already existed?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -456,6 +476,7 @@ def test_clone_cleans_up_preserves_directories_that_exist_a_priori():
             os.environ["PATH"] = old_path
 
 
+@pytest.mark.skip
 def test_clone_displays_nice_errors_for_missing_dependencies():
     """Does it tell the user what to install?"""
     HTML: SampleCollection = get_test_collection("html")
@@ -491,6 +512,7 @@ def test_clone_displays_nice_errors_for_missing_dependencies():
             os.environ["PATH"] = old_path
 
 
+@pytest.mark.skip
 def test_clone_succeeds_when_directory_exists_but_is_empty():
     """Does it clone into empty directories?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -502,6 +524,7 @@ def test_clone_succeeds_when_directory_exists_but_is_empty():
         clone(runner, ORIGINAL.col_file)
 
 
+@pytest.mark.skip
 def test_clone_generates_expected_notes():
     """Do generated note files match content of an example collection?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -523,6 +546,7 @@ def test_clone_generates_expected_notes():
         assert cloned_md5 == true_md5
 
 
+@pytest.mark.skip
 def test_clone_generates_deck_tree_correctly():
     """Does generated FS tree match example collection?"""
     MULTIDECK: SampleCollection = get_test_collection("multideck")
@@ -547,6 +571,7 @@ def test_clone_generates_deck_tree_correctly():
         assert cloned_md5 == true_md5
 
 
+@pytest.mark.skip
 def test_clone_generates_ki_subdirectory():
     """Does clone command generate .ki/ directory?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -561,6 +586,7 @@ def test_clone_generates_ki_subdirectory():
         assert os.path.isdir(kidir)
 
 
+@pytest.mark.skip
 def test_cloned_collection_is_git_repository():
     """Does clone run `git init` and stuff?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -573,6 +599,7 @@ def test_cloned_collection_is_git_repository():
         assert is_git_repo(ORIGINAL.repodir)
 
 
+@pytest.mark.skip
 def test_clone_commits_directory_contents():
     """Does clone leave user with an up-to-date repo?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -594,6 +621,7 @@ def test_clone_commits_directory_contents():
         assert len(commits) == 1
 
 
+@pytest.mark.skip
 def test_clone_leaves_collection_file_unchanged():
     """Does clone leave the collection alone?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -608,6 +636,7 @@ def test_clone_leaves_collection_file_unchanged():
         assert original_md5 == updated_md5
 
 
+@pytest.mark.skip
 def test_clone_directory_argument_works():
     """Does clone obey the target directory argument?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -624,6 +653,7 @@ def test_clone_directory_argument_works():
         assert os.path.isdir(target)
 
 
+@pytest.mark.skip
 def test_clone_writes_media_files():
     """Does clone copy media files from the media directory into 'MEDIA'?"""
     MEDIACOL: SampleCollection = get_test_collection("media")
@@ -636,6 +666,7 @@ def test_clone_writes_media_files():
         assert audio_path.is_file()
 
 
+@pytest.mark.skip
 def test_clone_handles_cards_from_a_single_note_in_distinct_decks(tmp_path: Path):
     SPLIT: SampleCollection = get_test_collection("split")
     runner = CliRunner()
@@ -649,6 +680,7 @@ def test_clone_handles_cards_from_a_single_note_in_distinct_decks(tmp_path: Path
 # PULL
 
 
+@pytest.mark.skip
 def test_pull_fails_if_collection_no_longer_exists():
     """Does ki pull only if `.anki2` file exists?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -665,6 +697,7 @@ def test_pull_fails_if_collection_no_longer_exists():
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_fails_if_collection_file_is_corrupted():
     """Does `pull()` fail gracefully when the collection file is bad?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -682,6 +715,7 @@ def test_pull_fails_if_collection_file_is_corrupted():
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_writes_changes_correctly():
     """Does ki get the changes from modified collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -701,6 +735,7 @@ def test_pull_writes_changes_correctly():
         assert os.path.isfile(NOTE_1)
 
 
+@pytest.mark.skip
 def test_pull_unchanged_collection_is_no_op():
     """Does ki remove remote before quitting?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -720,6 +755,7 @@ def test_pull_unchanged_collection_is_no_op():
         assert orig_hash == new_hash
 
 
+@pytest.mark.skip
 def test_pull_avoids_unnecessary_merge_conflicts():
     """Does ki prevent gratuitous merge conflicts?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -739,6 +775,7 @@ def test_pull_avoids_unnecessary_merge_conflicts():
         assert "Automatic merge failed; fix" not in out
 
 
+@pytest.mark.skip
 def test_pull_still_works_from_subdirectories():
     """Does pull still work if you're farther down in the directory tree than the repo route?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -757,6 +794,7 @@ def test_pull_still_works_from_subdirectories():
         pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_displays_errors_from_repo_ref():
     """Does 'pull()' return early when the last push commit ref is bad?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -777,6 +815,7 @@ def test_pull_displays_errors_from_repo_ref():
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_displays_errors_from_clone_helper(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -797,6 +836,7 @@ def test_pull_displays_errors_from_clone_helper(mocker: MockerFixture):
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_handles_unexpectedly_changed_checksums(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -815,6 +855,7 @@ def test_pull_handles_unexpectedly_changed_checksums(mocker: MockerFixture):
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_displays_errors_from_repo_initialization(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -835,6 +876,7 @@ def test_pull_displays_errors_from_repo_initialization(mocker: MockerFixture):
             pull(runner)
 
 
+@pytest.mark.skip
 def test_pull_preserves_reassigned_note_ids(tmp_path: Path):
     """UNFINISHED!"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -866,6 +908,7 @@ def test_pull_preserves_reassigned_note_ids(tmp_path: Path):
         logger.debug(out)
 
 
+@pytest.mark.skip
 def test_pull_handles_uncommitted_submodule_commits(tmp_path: Path):
     UNCOMMITTED_SM: SampleCollection = get_test_collection(
         "uncommitted_submodule_commits"
@@ -954,6 +997,7 @@ def test_pull_handles_uncommitted_submodule_commits(tmp_path: Path):
         assert expected_this in note_text
 
 
+@pytest.mark.skip
 def test_pull_removes_files_deleted_in_remote(tmp_path: Path):
     ORIGINAL: SampleCollection = get_test_collection("original")
     DELETED: SampleCollection = get_test_collection("deleted")
@@ -971,6 +1015,7 @@ def test_pull_removes_files_deleted_in_remote(tmp_path: Path):
         logger.debug(out)
 
 
+@pytest.mark.skip
 def test_pull_does_not_duplicate_decks_converted_to_subdecks_of_new_top_level_decks(tmp_path: Path):
     BEFORE: SampleCollection = get_test_collection("duplicated_subdeck_before")
     AFTER: SampleCollection = get_test_collection("duplicated_subdeck_after")
@@ -1001,6 +1046,7 @@ def test_pull_does_not_duplicate_decks_converted_to_subdecks_of_new_top_level_de
 # PUSH
 
 
+@pytest.mark.skip
 def test_push_writes_changes_correctly(tmp_path: Path):
     """If there are committed changes, does push change the collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1059,6 +1105,7 @@ def test_push_writes_changes_correctly(tmp_path: Path):
         assert len(new_notes) == 2
 
 
+@pytest.mark.skip
 def test_push_verifies_md5sum():
     """Does ki only push if md5sum matches last pull?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1077,6 +1124,7 @@ def test_push_verifies_md5sum():
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_generates_correct_backup():
     """Does push store a backup identical to old collection file?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1112,6 +1160,7 @@ def test_push_generates_correct_backup():
         assert backup_exists
 
 
+@pytest.mark.skip
 def test_push_doesnt_write_uncommitted_changes():
     """Does push only write changes that have been committed?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1133,6 +1182,7 @@ def test_push_doesnt_write_uncommitted_changes():
         assert len(os.listdir(".ki/backups")) == 0
 
 
+@pytest.mark.skip
 def test_push_doesnt_fail_after_pull():
     """Does push work if we pull and then edit and then push?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1172,6 +1222,7 @@ def test_push_doesnt_fail_after_pull():
         push(runner)
 
 
+@pytest.mark.skip
 def test_no_op_push_is_idempotent():
     """Does push not misbehave if you keep pushing?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1191,6 +1242,7 @@ def test_no_op_push_is_idempotent():
         push(runner)
 
 
+@pytest.mark.skip
 def test_push_deletes_notes():
     """Does push remove deleted notes from collection?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1222,6 +1274,7 @@ def test_push_deletes_notes():
         assert not os.path.isfile(NOTE_0)
 
 
+@pytest.mark.skip
 def test_push_still_works_from_subdirectories():
     """Does push still work if you're farther down in the directory tree than the repo route?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1247,6 +1300,7 @@ def test_push_still_works_from_subdirectories():
         push(runner)
 
 
+@pytest.mark.skip
 def test_push_deletes_added_notes():
     """Does push remove deleted notes added with ki?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1307,6 +1361,7 @@ def test_push_deletes_added_notes():
         assert len(notes) == 2
 
 
+@pytest.mark.skip
 def test_push_generates_correct_title_for_notes():
     """Does push use the truncated sort field as a filename?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1337,6 +1392,7 @@ def test_push_generates_correct_title_for_notes():
         assert "r.md" in notes
 
 
+@pytest.mark.skip
 def test_push_displays_informative_error_when_last_push_file_is_missing():
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1355,6 +1411,7 @@ def test_push_displays_informative_error_when_last_push_file_is_missing():
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_honors_ignore_patterns():
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1394,6 +1451,7 @@ def test_push_honors_ignore_patterns():
         assert "Warning: not Anki note" in out
 
 
+@pytest.mark.skip
 def test_push_displays_errors_from_head_ref_maybes(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1415,6 +1473,7 @@ def test_push_displays_errors_from_head_ref_maybes(mocker: MockerFixture):
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_displays_errors_from_head_repo_ref(mocker: MockerFixture):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1438,6 +1497,7 @@ def test_push_displays_errors_from_head_repo_ref(mocker: MockerFixture):
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_model_adding(
     mocker: MockerFixture,
 ):
@@ -1469,6 +1529,7 @@ def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_model_
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_push_flatnote_to_anki(
     mocker: MockerFixture,
 ):
@@ -1502,6 +1563,7 @@ def test_push_displays_errors_from_notetype_parsing_in_push_deltas_during_push_f
             logger.debug(out)
 
 
+@pytest.mark.skip
 def test_push_handles_submodules(tmp_path: Path):
     ORIGINAL: SampleCollection = get_test_collection("original")
     runner = CliRunner()
@@ -1535,6 +1597,7 @@ def test_push_handles_submodules(tmp_path: Path):
         assert "<br>z<br>" in notes[0]["Back"]
 
 
+@pytest.mark.skip
 def test_push_writes_media(tmp_path: Path):
     MEDIACOL: SampleCollection = get_test_collection("media")
     runner = CliRunner()
@@ -1566,6 +1629,7 @@ def test_push_writes_media(tmp_path: Path):
         assert len(check.unused) == 0
 
 
+@pytest.mark.skip
 def test_push_handles_foreign_models(tmp_path: Path):
     """Just check that we don't return an exception from `push()`."""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1583,6 +1647,7 @@ def test_push_handles_foreign_models(tmp_path: Path):
         logger.debug(out)
 
 
+@pytest.mark.skip
 def test_push_fails_if_database_is_locked():
     """Does ki print a nice error message when Anki is accidentally left open?"""
     ORIGINAL: SampleCollection = get_test_collection("original")
@@ -1602,6 +1667,7 @@ def test_push_fails_if_database_is_locked():
             push(runner)
 
 
+@pytest.mark.skip
 def test_push_is_nontrivial_when_pulled_changes_are_reverted(tmp_path: Path):
     """
     If you push, make changes in Anki, then pull those changes, then undo them
@@ -1661,6 +1727,7 @@ def test_push_is_nontrivial_when_pulled_changes_are_reverted(tmp_path: Path):
         assert "ki push: up to date." not in out
 
 
+@pytest.mark.skip
 def test_push_doesnt_unnecessarily_deduplicate_notetypes():
     """
     Does push refrain from adding a new notetype if the requested notetype
@@ -1725,6 +1792,7 @@ def test_push_doesnt_unnecessarily_deduplicate_notetypes():
         col.close(save=False)
 
 
+@pytest.mark.skip
 def test_push_is_nontrivial_when_pushed_changes_are_reverted_in_repository():
     """
     The following operation should be nontrivial:
@@ -1776,6 +1844,7 @@ def test_push_is_nontrivial_when_pushed_changes_are_reverted_in_repository():
         assert "ki push: up to date." not in out
 
 
+@pytest.mark.skip
 def test_push_changes_deck_for_moved_notes():
     MULTIDECK: SampleCollection = get_test_collection("multideck")
     runner = CliRunner()
@@ -1811,6 +1880,7 @@ def test_push_changes_deck_for_moved_notes():
         assert colnote.deck == "aa::dd"
 
 
+@pytest.mark.skip
 def test_push_is_trivial_for_committed_submodule_contents(tmp_path: Path):
     UNCOMMITTED_SM: SampleCollection = get_test_collection(
         "uncommitted_submodule_commits"
@@ -1876,4 +1946,5 @@ def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_
         repo.index.commit("Add subrepo.")
 
         out = push(runner)
+        logger.debug(out)
         assert "'git submodule add'" in out

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1873,6 +1873,7 @@ def test_push_prints_informative_warning_on_push_when_subrepo_was_added_instead_
 
         repo = git.Repo(".")
         repo.git.add(all=True)
+        repo.index.commit("Add subrepo.")
 
         out = push(runner)
         assert "'git submodule add'" in out


### PR DESCRIPTION
Fixes #55.