### PR TITLE
Fix grammar to support colons in `guid` fields.

### DIFF
--- a/ki/grammar.lark
+++ b/ki/grammar.lark
@@ -35,7 +35,7 @@ TITLECHAR: /[a-zA-Z0-9_-]/
 // === GUID ====
 
 // GUID field is allowed to be empty.
-GUID: "guid:" " "* (ANKICHAR*)? "\n"
+GUID: "guid:" " "* (GUIDCHAR*)? "\n"
 
 
 // = NOTETYPE ==
@@ -60,6 +60,7 @@ TAGNAME: /[^\s\0\x07\x08\x0b\x0c`"]/+
 // in the desktop client).
 ANKINAME: STARTENDCHAR ANKICHAR* (/[\t ]/+ ANKICHAR+)*
 ANKICHAR: /[^\s:{}"\0\x07\x08]/
+GUIDCHAR: /[^\s{}"\0\x07\x08]/
 STARTENDCHAR: /[^#^\/\s:{}"\0\x07\x08]/
 TRIPLEBACKTICKS: "```\n"
 

--- a/ki/grammar.lark
+++ b/ki/grammar.lark
@@ -60,7 +60,7 @@ TAGNAME: /[^\s\0\x07\x08\x0b\x0c`"]/+
 // in the desktop client).
 ANKINAME: STARTENDCHAR ANKICHAR* (/[\t ]/+ ANKICHAR+)*
 ANKICHAR: /[^\s:{}"\0\x07\x08]/
-GUIDCHAR: /[^\s{}"\0\x07\x08]/
+GUIDCHAR: /[^\s"\0\x07\x08]/
 STARTENDCHAR: /[^#^\/\s:{}"\0\x07\x08]/
 TRIPLEBACKTICKS: "```\n"
 

--- a/tests/data/notes/special_characters_in_guid.md
+++ b/tests/data/notes/special_characters_in_guid.md
@@ -1,6 +1,6 @@
 # Note
 ```
-guid: e&b23Z6:Bx
+guid: e&}2{Z6:Bx
 notetype: Basic
 ```
 

--- a/tests/data/notes/special_characters_in_guid.md
+++ b/tests/data/notes/special_characters_in_guid.md
@@ -1,0 +1,15 @@
+# Note
+```
+guid: e&b23Z6:Bx
+notetype: Basic
+```
+
+### Tags
+```
+```
+
+## Front
+100*16
+
+## Back
+1600

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -843,6 +843,16 @@ def test_tag_validation():
             assert err.char == char
 
 
+def test_parser_handles_special_characters_in_guid():
+    """In particular, does it allow colons?"""
+    parser = get_parser()
+    good = Path("tests/data/notes/special_characters_in_guid.md").read_text(encoding="UTF-8")
+    try:
+        parser.parse(good)
+    except UnexpectedToken as err:
+        raise err
+
+
 def test_parser_goods():
     """Try all good note examples."""
     parser = get_parser()


### PR DESCRIPTION
This commit fixes a bug where the definition of an `ANKICHAR` in the
note grammar specification did not allow colons. We replace this with a
`GUIDCHAR` terminal.
* Add test for above.