### PR TITLE
Fix difficult-to-track-down `PermissionError`

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for ki command line interface (CLI)."""
 import os
+import gc
 import sys
 import shutil
 import sqlite3
@@ -1121,6 +1122,9 @@ def test_push_doesnt_fail_after_pull():
         repo = git.Repo(ORIGINAL.repodir)
         repo.git.add(all=True)
         repo.index.commit("Added 'e'.")
+        repo.close()
+        del repo
+        gc.collect()
 
         # Push changes.
         os.chdir(ORIGINAL.repodir)


### PR DESCRIPTION
This was supposed to be fixed by #83, but it's flaky and I am unable to reproduce it on my local Windows box. Hopefully a few well-placed `del` and `gc.collect()` calls will fix it for good.