### PR TITLE
Fix bug where special chars in filenames from `guid`s crash on `win32`.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==7.1.2
 pytest-mock
 pytest-timeout
 checksumdir==1.2.0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1497,7 +1497,6 @@ def test_push_writes_media(tmp_path: Path):
     with runner.isolated_filesystem(temp_dir=tmp_path):
 
         # Clone.
-        logger.debug(f"First clone...")
         clone(runner, MEDIACOL.col_file)
 
         # Add a new note file containing media, and the corresponding media file.
@@ -1505,13 +1504,11 @@ def test_push_writes_media(tmp_path: Path):
         media_note_path = root / MEDIACOL.repodir / "Default" / MEDIA_NOTE
         media_file_path = root / MEDIACOL.repodir / "Default" / MEDIA / MEDIA_FILENAME
         onesec_file = root / MEDIACOL.repodir / "Default" / MEDIA / "1sec.mp3"
-        logger.debug(f"Copying media file to '{media_file_path}'")
         shutil.copyfile(MEDIA_NOTE_PATH, media_note_path)
         shutil.copyfile(MEDIA_FILE_PATH, media_file_path)
         os.chdir(MEDIACOL.repodir)
 
         mode: int = ki.filemode(onesec_file)
-        logger.warning(f"1sec.mp3: {mode = }")
 
         # Commit the additions.
         repo = git.Repo(F.cwd())
@@ -1520,7 +1517,6 @@ def test_push_writes_media(tmp_path: Path):
         repo.close()
 
         mode: int = ki.filemode(onesec_file)
-        logger.warning(f"1sec.mp3: {mode = }")
 
         # Push the commit.
         out = push(runner)
@@ -1530,7 +1526,6 @@ def test_push_writes_media(tmp_path: Path):
         F.rmtree(F.test(Path(MEDIACOL.repodir)))
 
         # Re-clone the pushed collection.
-        logger.debug(f"Second clone...")
         out = clone(runner, MEDIACOL.col_file)
 
         # Check that added note and media file exist.
@@ -1865,9 +1860,9 @@ def test_push_correctly_encodes_quotes_in_html_tags(tmp_path: Path):
         # Clone collection in cwd.
         clone(runner, BROKEN.col_file)
         os.chdir(BROKEN.repodir)
-
         note_file = (
-            Path("🧙‍Recommendersysteme") / "wie-sieht-die-linkstruktur-von-einem-hub.md"
+            Path("🧙‍Recommendersysteme")
+            / "wie-sieht-die-linkstruktur-von-einem-hub-in-einem-web-graphe.md"
         )
         with open(note_file, "r", encoding="UTF-8") as read_f:
             contents = read_f.read().replace("guter", "guuter")


### PR DESCRIPTION
This commit fixes a bug in the implementation of `get_note_path()` where the failsafe slugs that are autogenerated from the `guid`s of each note are allowed to contain characters that are invalid path chars on Windows. This is a vestigial feature of when we used to do the same thing to generate slugs when we were using `nid`s instead of `guid`s. Additionally, we spruce up the slug generation logic in `get_note_path()` to use more of the note's payload. We now take content from all fields when trying to generate a nice filename, and when that fials, we hash the guid of the note file using `blake2`, and construct a nice-looking filename `<notetype>--<hash>--<datetime>.md` that is a vast improvement over the previous format (`<nid>.md`). The tests are refactored accordingly, we add a new test for for special characters in paths on Windows.

* Make `backup()` return an integer status code.
* Bump `MAX_FILENAME_LEN` from `40` to `60`.
* Pin `pytest` version to `7.1.2`.
* Add `test_write_deck_node_cards_does_not_fail_due_to_special_characters_in_paths_on_windows()`.
* Remove `logger.debug()` calls from several tests.
* Refactor `test_write_repository_displays_missing_media_warnings()` to avoid use of `capfd` fixture, which sometimes crashes pytest on Windows.
* Add type hints for all uses of `tmp_path: Path` fixture.
* Replace use of `capfd` fixture in `test_backup_is_no_op_when_backup_already_exists()` with a mock.
* Remove use of `capfd` from `test_diff2_shows_no_changes_when_no_changes_have_been_made()`.
* Refactor `test_get_note_path_produces_nonempty_filenames()` to reflect new implementation.
* Add helper function `get_basic_colnote_with_fields()` for tests.

Should fix #87.