### PR TITLE
Add test that gitpython doesn't crash on paths containing colons.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 anki==2.1.51
 loguru==0.6.0
-gitpython==3.1.27
+gitpython @ git+https://github.com/langfield/gitpython.git@main#egg=gitpython
 tqdm==4.63.1
 lark==1.1.2
 prettyprinter==0.18.0


### PR DESCRIPTION
This commit replaces gitpython 3.1.27 with a patched fork that fixes diff behavior for paths containing special characters. The added test is only run on POSIX, because Windows does not support paths containing special characters.

* Add `test_diff2_handles_paths_containing_colons()`.