### PR TITLE
Fix bug where `[no deck]/` is written to filesystem (did == 0).

### DIFF
--- a/ki/maybes.py
+++ b/ki/maybes.py
@@ -40,6 +40,7 @@ from ki.types import (
     Field,
     ColNote,
     Deck,
+    Root,
     DotKi,
     PlannedLink,
     Notetype,
@@ -457,13 +458,23 @@ def deckd(deck_name: str, targetdir: Dir) -> Dir:
 
 
 @beartype
-def tree(col: Collection, targetd: Dir, root: DeckTreeNode) -> Deck:
+def tree(col: Collection, targetd: Dir, root: DeckTreeNode) -> Union[Root, Deck]:
     """Get the deck directory and did for a decknode."""
     did = root.deck_id
     name = col.decks.name(did)
+    children: List[Deck] = list(map(partial(M.tree, col, targetd), root.children))
+    if root.deck_id == 0:
+        deckd, mediad = None, None
+        return Root(
+            did=did,
+            node=root,
+            deckd=None,
+            mediad=None,
+            fullname=name,
+            children=children,
+        )
     deckd = M.deckd(name, targetd)
     mediad: Dir = F.force_mkdir(deckd / MEDIA)
-    children: List[Deck] = list(map(partial(M.tree, col, targetd), root.children))
     return Deck(
         did=did,
         node=root,

--- a/ki/types.py
+++ b/ki/types.py
@@ -273,6 +273,17 @@ class Deck:
 
 @beartype
 @dataclass(frozen=True)
+class Root:
+    did: DeckId
+    node: DeckTreeNode
+    deckd: None
+    mediad: None
+    children: List[Deck]
+    fullname: str
+
+
+@beartype
+@dataclass(frozen=True)
 class PlannedLink:
     """A not-yet-created symlink path and its extant target."""
 

--- a/tests/test_ki.py
+++ b/tests/test_ki.py
@@ -79,6 +79,7 @@ from ki import (
     add_db_note,
     tidy_html_recursively,
     media_filenames_in_field,
+    write_decks,
 )
 from ki.types import (
     NoFile,
@@ -1646,3 +1647,13 @@ def test_media_filenames_in_field_strips_newlines(mocker: MockerFixture):
     fnames: Iterable[str] = media_filenames_in_field(mock, s)
     assert not any(map(lambda f: "\n" in f, fnames))
     assert not any(map(lambda f: "\\n" in f, fnames))
+
+
+def test_write_decks_skips_root_deck(tmp_path: Path):
+    """Is `[no deck]` skipped (as it should be)?"""
+    ORIGINAL: SampleCollection = get_test_collection("original")
+    col = open_collection(ORIGINAL.col_file)
+    nids: Iterable[int] = col.find_notes(query="")
+    colnotes: Dict[int, ColNote] = {nid: M.colnote(col, nid) for nid in nids}
+    links: Set[WindowsLink] = write_decks(col, Dir(tmp_path), colnotes, {}, {})
+    assert not os.path.isdir(tmp_path / "[no deck]")


### PR DESCRIPTION
This commit adds a test that makes sure we don't write the latent root deck (parent of all top-level decks) to the filesystem by accident.

* Add `Root` type.
* Refactor `preorder()` and `postorder()`.
* Refactor `parentmap()`.
* Refactor `write_decks()`.
* Make `M.tree()` return either a `Root` or a `Deck`.
* Add `test_write_decks_skips_root_deck()`.