### PR TITLE
Fix `GitCommandError` about `unknown option: 'initial-branch=main'`

### DIFF
--- a/ki/functional.py
+++ b/ki/functional.py
@@ -59,6 +59,7 @@ GIT = ".git"
 GITMODULES_FILE = ".gitmodules"
 PIPE = subprocess.PIPE
 STDOUT = subprocess.STDOUT
+BRANCH_NAME = "main"
 
 # Emoji regex character classes.
 EMOJIS = "\U0001F600-\U0001F64F"
@@ -383,6 +384,18 @@ def unsubmodule(repo: git.Repo) -> git.Repo:
         repo.git.rm(gitmodules_file)
         _ = repo.index.commit("Remove `.gitmodules` file.")
     return repo
+
+
+@beartype
+def init(targetdir: Dir) -> Tuple[git.Repo, str]:
+    """Run `git init`, returning the repo and initial branch name."""
+    branch = BRANCH_NAME
+    try:
+        repo = git.Repo.init(targetdir, initial_branch=BRANCH_NAME)
+    except git.GitCommandError:
+        branch = "master"
+        repo = git.Repo.init(targetdir)
+    return repo, branch
 
 
 @beartype

--- a/submodule.py
+++ b/submodule.py
@@ -8,7 +8,7 @@ import git_filter_repo
 from beartype import beartype
 from beartype.typing import List
 
-from ki import copy_repo, BRANCH_NAME
+from ki import cp_repo, BRANCH_NAME
 from ki.types import Dir, Rev
 import ki.maybes as M
 import ki.functional as F


### PR DESCRIPTION
This PR (ostensibly) fixes #118. For context, users running git versions lower than 2.28 will likely run into this, because the above command-line flag did not exist prior to this version.

We fix this by catching the exception and defaulting to `master` in case we get a failure.

* Make `_clone()` return branch name instead of `md5sum`, which wasn't used anyway.
* Add `F.init()` to safely initialize repos.
* Fix broken import/name in `submodule.py`.