### PR TITLE
fix submodule.py script to handle empty directories

### DIFF
--- a/submodule.py
+++ b/submodule.py
@@ -94,6 +94,12 @@ def main() -> None:
     repo.git.rm(args.deck, r=True)
     repo.index.commit(f"Remove '{args.deck}'")
 
+    # Remove folder in case git does not remove it.
+    # This happens if there are empty folders inside the removed desks folder, such as _media
+    deskdir: Dir = F.root(repo).joinpath(args.deck)
+    if deskdir.exists():
+        F.rmtree(deskdir)
+
     # Add, initialize, and update the submodule.
     repo.git.submodule("add", args.remote, args.deck)
     repo.git.submodule("init")


### PR DESCRIPTION
When converting a desk into a submodule, the original folder gets rm'ed from the git repo. However, git rm does not always remove the folder: if there are untracked objects inside the folder (such as an empty _media) folder, it does not remove it.

This commit adds a check for that, and if it was not removed manually removes the folder.

This was disscussed in https://github.com/langfield/ki/issues/128