### PR TITLE
Treat case where `repo.git.rm` fails on dirs with no files

### DIFF
--- a/submodule.py
+++ b/submodule.py
@@ -90,8 +90,16 @@ def main() -> None:
     out = copy.git.push("--set-upstream", REMOTE_NAME, BRANCH_NAME, force=True)
     print(out)
 
-    # Remove the deck and commit the deletion.
-    repo.git.rm(args.deck, r=True)
+    # Remove the deck and commit the deletion in the original repo.
+    F.chdir(kirepo.root)
+    try:
+        repo.git.rm(args.deck, r=True, f=True)
+    except git.exc.GitCommandError as err:
+        if "did not match any files" not in err.stderr:
+            raise err
+    deck = F.chk(Path(args.deck))
+    if isinstance(deck, Dir):
+        F.rmtree(deck)
     repo.index.commit(f"Remove '{args.deck}'")
 
     # Add, initialize, and update the submodule.


### PR DESCRIPTION
A fix for the following sub-issue raised within #128.

> I've ran everything as mentioned here:
> 
> > So here's how you'd do this.
> > 
> > 1. Clone this repository, put `submodule.py` somewhere you can find it.
> > 2. Create a new Github repository for your submodule, perhaps `git@github.com:abbradar/mydeck.git`.
> > 3. Let's assume your cloned collection is in your home directory, and that's where you put `submodule.py` as well. Then run `python3 submodule.py --kirepo collection/ --deck my-deck --remote git@github.com:abbradar/mydeck.git`.
> > 
> > That should do it.
> 
> I've created a desk called `programming`, ran the submodule script on it. Worked fine, after I added at least one file to the `_media` folder (**otherwise the `git rm` call inside the `submodule.py` script does not remove all folders, and the script subsequently fails**).