### PR TITLE
Lint tests directory

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/ki/__init__.py
+++ b/ki/__init__.py
@@ -1728,6 +1728,7 @@ def pull() -> None:
     hashes = list(filter(lambda l: l != "", hashes))
     if md5sum in hashes[-1]:
         echo("ki pull: up to date.")
+        unlock(con)
         return
 
     _pull(kirepo)
@@ -1947,6 +1948,7 @@ def push() -> PushResult:
     # If there are no changes, quit.
     if len(set(deltas)) == 0:
         echo("ki push: up to date.")
+        unlock(con)
         return PushResult.UP_TO_DATE
 
     echo(f"Pushing to '{kirepo.col_file}'")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ tqdm==4.63.1
 click==8.1.3
 colorama==0.4.4
 beartype==0.11.0
-gitpython @ git+https://github.com/gitpython-developers/GitPython.git@183cf3509f2a1646daaca1874594a27abb408deb
+gitpython==3.1.30
 whatthepatch==1.0.2
+git-filter-repo==2.38.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_file(filename):
 
 setuptools.setup(
     name="ki",
-    version="0.0.13a",
+    version="0.0.14a",
     description="",
     url="",
     author="",

--- a/submodule.py
+++ b/submodule.py
@@ -103,7 +103,7 @@ def main() -> None:
     repo.index.commit(f"Remove '{args.deck}'")
 
     # Add, initialize, and update the submodule.
-    repo.git.submodule("add", args.remote, args.deck)
+    repo.create_submodule(url=args.remote, name=args.deck, path=args.deck, allow_unsafe_protocols=True)
     repo.git.submodule("init")
     repo.git.submodule("update")
 

--- a/tests/test_ki.py
+++ b/tests/test_ki.py
@@ -68,7 +68,6 @@ from ki import (
     check_fields_health,
     is_anki_note,
     parse_note,
-    lock,
     write_repository,
     get_target,
     push_note,
@@ -86,13 +85,11 @@ from ki import (
 from ki.types import (
     NoFile,
     PseudoFile,
-    WindowsLink,
     ExpectedEmptyDirectoryButGotNonEmptyDirectoryError,
     StrangeExtantPathError,
     MissingNotetypeError,
     MissingFieldOrdinalError,
     MissingNoteIdError,
-    ExpectedNonexistentPathError,
     DiffTargetFileNotFoundWarning,
     NotetypeKeyError,
     UnnamedNotetypeError,
@@ -1624,7 +1621,11 @@ def test_diff2_handles_paths_containing_colons(tmp_path: Path):
 
 def test_media_filenames_in_field_strips_newlines(mocker: MockerFixture):
     """Are newlines stripped from all found media filenames?"""
-    s = 'Wie sieht die Linkstruktur von einem Hub in einem Web-Graphen aus?\x1fEin guter Hub zeigt auf viele Authorities:\n<div><img src=\n"paste-64c7a314b90f3e9ef1b2d94edb396e07a121afdf.jpg"></div>'
+    s = (
+        "Wie sieht die Linkstruktur von einem Hub in einem Web-Graphen aus?"
+        "\x1fEin guter Hub zeigt auf viele Authorities:"
+        '\n<div><img src=\n"paste-64c7a314b90f3e9ef1b2d94edb396e07a121afdf.jpg"></div>'
+    )
     mock = mocker.MagicMock()
     mock.__class__ = Collection
     mock.media.regexps = [
@@ -1645,7 +1646,7 @@ def test_write_decks_skips_root_deck(tmp_path: Path):
     col = open_collection(ORIGINAL.col_file)
     nids: Iterable[int] = col.find_notes(query="")
     colnotes: Dict[int, ColNote] = {nid: M.colnote(col, nid) for nid in nids}
-    links: Set[WindowsLink] = write_decks(col, Dir(tmp_path), colnotes, {}, {})
+    write_decks(col, Dir(tmp_path), colnotes, {}, {})
     assert not os.path.isdir(tmp_path / "[no deck]")
 
 
@@ -1707,7 +1708,7 @@ def test_write_decks_warns_about_media_deck_name_collisions(
     nids: Iterable[int] = col.find_notes(query="")
     colnotes: Dict[int, ColNote] = {nid: M.colnote(col, nid) for nid in nids}
     mock = mocker.patch("ki.warn")
-    links: Set[WindowsLink] = write_decks(col, Dir(tmp_path), colnotes, {}, {})
+    write_decks(col, Dir(tmp_path), colnotes, {}, {})
 
     mock.assert_called_once()
     args = mock.call_args

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Test that imports work okay."""
+# pylint: disable=unused-import
 import ki
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -840,6 +840,7 @@ def test_tag_validation():
         if isinstance(err, UnexpectedCharacters):
             assert err.char == char
 
+
 WEIRD_BUG = r"""# Note
 ```
 guid: L>KHLS3F1w
@@ -861,14 +862,19 @@ Ctrl+L
 
 """
 
+
 def test_parser_handles_leading_newlines_in_fields():
     """Does the parser handle this seemingly fine note?"""
     parser = get_parser()
     transformer = NoteTransformer()
     tree = parser.parse(WEIRD_BUG)
     flatnote = transformer.transform(tree)
-    assert flatnote.fields["Front"] == "\nEdit the layout/card types from the editor or browser\n"
+    assert (
+        flatnote.fields["Front"]
+        == "\nEdit the layout/card types from the editor or browser\n"
+    )
     assert flatnote.fields["Back"] == "\nCtrl+L\n"
+
 
 def test_parser_handles_special_characters_in_guid():
     """In particular, does it allow colons?"""


### PR DESCRIPTION
This commit bumps the versions of several dependencies, fixes a minor bug where we didn't call `unlock()` in the trivial cases during `pull()`s and `push()`s, and refactors the tests a bit.

Fixes #144.