### PR TITLE
Preserve newlines nicely, handle trailing newlines

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1610,18 +1610,19 @@ def write_note(
     colnote: ColNote,
 ) -&gt; File:
     decknames = set(map(lambda c: c.col.decks.name(c.did), colnote.n.cards()))
+    sortf = colnote.sortf_text
     if len(decknames) == 0:
-        raise ValueError(f&#34;No cards for note: {colnote}&#34;)
+        raise ValueError(f&#34;No cards for note: {sortf}&#34;)
     if len(decknames) &gt; 1:
-        raise ValueError(f&#34;Cards for note {colnote} are in distinct decks: {decknames}&#34;)
+        raise ValueError(f&#34;Cards for note {sortf} are in distinct decks: {decknames}&#34;)
     fullname = decknames.pop()
     parts = fullname.split(&#34;::&#34;)
     if &#34;_media&#34; in parts:
         raise ValueError(f&#34;Bad deck name &#39;{fullname}&#39; (cannot contain &#39;_media&#39;)&#34;)
     deck: Deck = deckmap[fullname]
+    path: NoFile = get_note_path(colnote, deck.deckd)
     payload: str = get_note_payload(colnote)
-    note_path: NoFile = get_note_path(colnote, deck.deckd)
-    return F.write(note_path, payload)
+    return F.write(path, payload)
 
 
 @curried
@@ -1737,7 +1738,7 @@ def html_to_screen(html: str) -&gt; str:
     plain = re.sub(&#39;src= ?\n&#34;&#39;, &#39;src=&#34;&#39;, plain)
 
     plain = re.sub(r&#34;\&lt;b\&gt;\s*\&lt;\/b\&gt;&#34;, &#34;&#34;, plain)
-    return plain.strip()
+    return plain
 
 
 @curried
@@ -3157,7 +3158,7 @@ def html_to_screen(html: str) -&gt; str:
     plain = re.sub(&#39;src= ?\n&#34;&#39;, &#39;src=&#34;&#39;, plain)
 
     plain = re.sub(r&#34;\&lt;b\&gt;\s*\&lt;\/b\&gt;&#34;, &#34;&#34;, plain)
-    return plain.strip()</code></pre>
+    return plain</code></pre>
 </details>
 </dd>
 <dt id="ki.is_anki_note"><code class="name flex">
@@ -4059,18 +4060,19 @@ def write_note(
     colnote: ColNote,
 ) -&gt; File:
     decknames = set(map(lambda c: c.col.decks.name(c.did), colnote.n.cards()))
+    sortf = colnote.sortf_text
     if len(decknames) == 0:
-        raise ValueError(f&#34;No cards for note: {colnote}&#34;)
+        raise ValueError(f&#34;No cards for note: {sortf}&#34;)
     if len(decknames) &gt; 1:
-        raise ValueError(f&#34;Cards for note {colnote} are in distinct decks: {decknames}&#34;)
+        raise ValueError(f&#34;Cards for note {sortf} are in distinct decks: {decknames}&#34;)
     fullname = decknames.pop()
     parts = fullname.split(&#34;::&#34;)
     if &#34;_media&#34; in parts:
         raise ValueError(f&#34;Bad deck name &#39;{fullname}&#39; (cannot contain &#39;_media&#39;)&#34;)
     deck: Deck = deckmap[fullname]
+    path: NoFile = get_note_path(colnote, deck.deckd)
     payload: str = get_note_payload(colnote)
-    note_path: NoFile = get_note_path(colnote, deck.deckd)
-    return F.write(note_path, payload)</code></pre>
+    return F.write(path, payload)</code></pre>
 </details>
 </dd>
 <dt id="ki.write_repository"><code class="name flex">

--- a/docs/transformer.html
+++ b/docs/transformer.html
@@ -119,9 +119,10 @@ class NoteTransformer(Transformer):
         assert isinstance(header, Header)
         assert isinstance(fields[0], Field)
 
+        # We drop the first character because it is a newline.
         fieldmap: Dict[str, str] = {}
         for field in fields:
-            fieldmap[field.title] = field.content
+            fieldmap[field.title] = field.content[1:]
 
         return FlatNote(
             title=header.title,
@@ -154,25 +155,26 @@ class NoteTransformer(Transformer):
         lines = f[1:]
         content = &#34;&#34;.join(lines)
         if content[-2:] != &#34;\n\n&#34;:
-            print(lines)
             raise RuntimeError(
                 f&#34;Nonterminating fields must have &gt;= 1 trailing empty line:\n{content}&#34;
             )
-        return Field(fheader, content[:-2])
+        return Field(fheader, content[:-1])
 
     @beartype
-    def terminalfield(self, f: List[str]) -&gt; Field:
+    def lastfield(self, f: List[str]) -&gt; Field:
         assert len(f) &gt;= 1
         fheader = f[0]
         lines = f[1:]
         content = &#34;&#34;.join(lines)
-        return Field(fheader, content[:-1])
+        if len(content) &gt; 0 and content[-1] == &#34;\n&#34;:
+            content = content[:-1]
+        return Field(fheader, content)
 
     @beartype
     def fieldheader(self, f: List[str]) -&gt; str:
-        &#34;&#34;&#34;``fieldheader: FIELDSENTINEL &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
-        assert len(f) == 2
-        return f[1]
+        &#34;&#34;&#34;``fieldheader: &#34;##&#34; &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
+        assert len(f) == 1
+        return f[0]
 
     @beartype
     def GUID(self, t: Token) -&gt; str:
@@ -389,9 +391,10 @@ s</p></div>
         assert isinstance(header, Header)
         assert isinstance(fields[0], Field)
 
+        # We drop the first character because it is a newline.
         fieldmap: Dict[str, str] = {}
         for field in fields:
-            fieldmap[field.title] = field.content
+            fieldmap[field.title] = field.content[1:]
 
         return FlatNote(
             title=header.title,
@@ -424,25 +427,26 @@ s</p></div>
         lines = f[1:]
         content = &#34;&#34;.join(lines)
         if content[-2:] != &#34;\n\n&#34;:
-            print(lines)
             raise RuntimeError(
                 f&#34;Nonterminating fields must have &gt;= 1 trailing empty line:\n{content}&#34;
             )
-        return Field(fheader, content[:-2])
+        return Field(fheader, content[:-1])
 
     @beartype
-    def terminalfield(self, f: List[str]) -&gt; Field:
+    def lastfield(self, f: List[str]) -&gt; Field:
         assert len(f) &gt;= 1
         fheader = f[0]
         lines = f[1:]
         content = &#34;&#34;.join(lines)
-        return Field(fheader, content[:-1])
+        if len(content) &gt; 0 and content[-1] == &#34;\n&#34;:
+            content = content[:-1]
+        return Field(fheader, content)
 
     @beartype
     def fieldheader(self, f: List[str]) -&gt; str:
-        &#34;&#34;&#34;``fieldheader: FIELDSENTINEL &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
-        assert len(f) == 2
-        return f[1]
+        &#34;&#34;&#34;``fieldheader: &#34;##&#34; &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
+        assert len(f) == 1
+        return f[0]
 
     @beartype
     def GUID(self, t: Token) -&gt; str:
@@ -599,18 +603,17 @@ def field(self, f: List[str]) -&gt; Field:
     lines = f[1:]
     content = &#34;&#34;.join(lines)
     if content[-2:] != &#34;\n\n&#34;:
-        print(lines)
         raise RuntimeError(
             f&#34;Nonterminating fields must have &gt;= 1 trailing empty line:\n{content}&#34;
         )
-    return Field(fheader, content[:-2])</code></pre>
+    return Field(fheader, content[:-1])</code></pre>
 </details>
 </dd>
 <dt id="ki.transformer.NoteTransformer.fieldheader"><code class="name flex">
 <span>def <span class="ident">fieldheader</span></span>(<span>self, f: list[str]) ‑> str</span>
 </code></dt>
 <dd>
-<div class="desc"><p><code>fieldheader: FIELDSENTINEL " "* ANKINAME "
+<div class="desc"><p><code>fieldheader: "##" " "* ANKINAME "
 "+</code></p></div>
 <details class="source">
 <summary>
@@ -618,9 +621,9 @@ def field(self, f: List[str]) -&gt; Field:
 </summary>
 <pre><code class="python">@beartype
 def fieldheader(self, f: List[str]) -&gt; str:
-    &#34;&#34;&#34;``fieldheader: FIELDSENTINEL &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
-    assert len(f) == 2
-    return f[1]</code></pre>
+    &#34;&#34;&#34;``fieldheader: &#34;##&#34; &#34; &#34;* ANKINAME &#34;\n&#34;+``&#34;&#34;&#34;
+    assert len(f) == 1
+    return f[0]</code></pre>
 </details>
 </dd>
 <dt id="ki.transformer.NoteTransformer.header"><code class="name flex">
@@ -636,6 +639,26 @@ def fieldheader(self, f: List[str]) -&gt; str:
 def header(self, h: List[str]) -&gt; Header:
     h = filter(lambda s: s != BACKTICKS, h)
     return Header(*h)</code></pre>
+</details>
+</dd>
+<dt id="ki.transformer.NoteTransformer.lastfield"><code class="name flex">
+<span>def <span class="ident">lastfield</span></span>(<span>self, f: list[str]) ‑> <a title="ki.transformer.Field" href="#ki.transformer.Field">Field</a></span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@beartype
+def lastfield(self, f: List[str]) -&gt; Field:
+    assert len(f) &gt;= 1
+    fheader = f[0]
+    lines = f[1:]
+    content = &#34;&#34;.join(lines)
+    if len(content) &gt; 0 and content[-1] == &#34;\n&#34;:
+        content = content[:-1]
+    return Field(fheader, content)</code></pre>
 </details>
 </dd>
 <dt id="ki.transformer.NoteTransformer.note"><code class="name flex">
@@ -657,9 +680,10 @@ def note(self, n: List[Union[Header, List[str], Field]]) -&gt; FlatNote:
     assert isinstance(header, Header)
     assert isinstance(fields[0], Field)
 
+    # We drop the first character because it is a newline.
     fieldmap: Dict[str, str] = {}
     for field in fields:
-        fieldmap[field.title] = field.content
+        fieldmap[field.title] = field.content[1:]
 
     return FlatNote(
         title=header.title,
@@ -683,24 +707,6 @@ def note(self, n: List[Union[Header, List[str], Field]]) -&gt; FlatNote:
 def tags(self, tags: List[Optional[str]]) -&gt; List[str]:
     tags = filter(lambda t: t != BACKTICKS, tags)
     return [tag for tag in tags if tag is not None]</code></pre>
-</details>
-</dd>
-<dt id="ki.transformer.NoteTransformer.terminalfield"><code class="name flex">
-<span>def <span class="ident">terminalfield</span></span>(<span>self, f: list[str]) ‑> <a title="ki.transformer.Field" href="#ki.transformer.Field">Field</a></span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@beartype
-def terminalfield(self, f: List[str]) -&gt; Field:
-    assert len(f) &gt;= 1
-    fheader = f[0]
-    lines = f[1:]
-    content = &#34;&#34;.join(lines)
-    return Field(fheader, content[:-1])</code></pre>
 </details>
 </dd>
 <dt id="ki.transformer.NoteTransformer.title"><code class="name flex">
@@ -781,9 +787,9 @@ def title(self, t: List[str]) -&gt; str:
 <li><code><a title="ki.transformer.NoteTransformer.field" href="#ki.transformer.NoteTransformer.field">field</a></code></li>
 <li><code><a title="ki.transformer.NoteTransformer.fieldheader" href="#ki.transformer.NoteTransformer.fieldheader">fieldheader</a></code></li>
 <li><code><a title="ki.transformer.NoteTransformer.header" href="#ki.transformer.NoteTransformer.header">header</a></code></li>
+<li><code><a title="ki.transformer.NoteTransformer.lastfield" href="#ki.transformer.NoteTransformer.lastfield">lastfield</a></code></li>
 <li><code><a title="ki.transformer.NoteTransformer.note" href="#ki.transformer.NoteTransformer.note">note</a></code></li>
 <li><code><a title="ki.transformer.NoteTransformer.tags" href="#ki.transformer.NoteTransformer.tags">tags</a></code></li>
-<li><code><a title="ki.transformer.NoteTransformer.terminalfield" href="#ki.transformer.NoteTransformer.terminalfield">terminalfield</a></code></li>
 <li><code><a title="ki.transformer.NoteTransformer.title" href="#ki.transformer.NoteTransformer.title">title</a></code></li>
 </ul>
 </li>

--- a/ki/__init__.py
+++ b/ki/__init__.py
@@ -986,18 +986,19 @@ def write_note(
     colnote: ColNote,
 ) -> File:
     decknames = set(map(lambda c: c.col.decks.name(c.did), colnote.n.cards()))
+    sortf = colnote.sortf_text
     if len(decknames) == 0:
-        raise ValueError(f"No cards for note: {colnote}")
+        raise ValueError(f"No cards for note: {sortf}")
     if len(decknames) > 1:
-        raise ValueError(f"Cards for note {colnote} are in distinct decks: {decknames}")
+        raise ValueError(f"Cards for note {sortf} are in distinct decks: {decknames}")
     fullname = decknames.pop()
     parts = fullname.split("::")
     if "_media" in parts:
         raise ValueError(f"Bad deck name '{fullname}' (cannot contain '_media')")
     deck: Deck = deckmap[fullname]
+    path: NoFile = get_note_path(colnote, deck.deckd)
     payload: str = get_note_payload(colnote)
-    note_path: NoFile = get_note_path(colnote, deck.deckd)
-    return F.write(note_path, payload)
+    return F.write(path, payload)
 
 
 @curried
@@ -1113,7 +1114,7 @@ def html_to_screen(html: str) -> str:
     plain = re.sub('src= ?\n"', 'src="', plain)
 
     plain = re.sub(r"\<b\>\s*\<\/b\>", "", plain)
-    return plain.strip()
+    return plain
 
 
 @curried

--- a/ki/grammar.lark
+++ b/ki/grammar.lark
@@ -2,18 +2,18 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ NOTE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // A ``note`` is a group of exactly 1 ``header`` and at least 1 ``field``.
-note: header "\n" tags "\n" field* terminalfield
+note: header "\n" tags "\n" field* lastfield
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ FIELD ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 // Only allow one newline after a field, but it can have many newlines within
 // it, and fields can be empty.
-field: fieldheader LF* FIELDLINE*
-terminalfield: fieldheader LF* FIELDLINE*
-fieldheader: FIELDSENTINEL " "* ANKINAME "\n"
-FIELDLINE: /(?!##)(?:[^\0\x07\x08\x0b\x0c\r\n])+/ "\n"+
-FIELDSENTINEL: "##"
+field: fieldheader FIELDLINE*
+lastfield: fieldheader FIELDLINE*
+fieldheader: "##" " "* ANKINAME
+FIELDLINE: "\n" FIELDCHAR*
+FIELDCHAR: /(?!##)(?:[^\0\x07\x08\x0b\x0c\r\n])/
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ HEADER ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ki/transformer.py
+++ b/ki/transformer.py
@@ -87,9 +87,10 @@ class NoteTransformer(Transformer):
         assert isinstance(header, Header)
         assert isinstance(fields[0], Field)
 
+        # We drop the first character because it is a newline.
         fieldmap: Dict[str, str] = {}
         for field in fields:
-            fieldmap[field.title] = field.content
+            fieldmap[field.title] = field.content[1:]
 
         return FlatNote(
             title=header.title,
@@ -122,25 +123,26 @@ class NoteTransformer(Transformer):
         lines = f[1:]
         content = "".join(lines)
         if content[-2:] != "\n\n":
-            print(lines)
             raise RuntimeError(
                 f"Nonterminating fields must have >= 1 trailing empty line:\n{content}"
             )
-        return Field(fheader, content[:-2])
+        return Field(fheader, content[:-1])
 
     @beartype
-    def terminalfield(self, f: List[str]) -> Field:
+    def lastfield(self, f: List[str]) -> Field:
         assert len(f) >= 1
         fheader = f[0]
         lines = f[1:]
         content = "".join(lines)
-        return Field(fheader, content[:-1])
+        if len(content) > 0 and content[-1] == "\n":
+            content = content[:-1]
+        return Field(fheader, content)
 
     @beartype
     def fieldheader(self, f: List[str]) -> str:
-        """``fieldheader: FIELDSENTINEL " "* ANKINAME "\n"+``"""
-        assert len(f) == 2
-        return f[1]
+        """``fieldheader: "##" " "* ANKINAME "\n"+``"""
+        assert len(f) == 1
+        return f[0]
 
     @beartype
     def GUID(self, t: Token) -> str:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read_file(filename):
 
 setuptools.setup(
     name="ki",
-    version="0.0.14a",
+    version="0.0.15a",
     description="",
     url="",
     author="",


### PR DESCRIPTION
This makes slight changes to the parser in pursuit of having `push . clone` and `push . pull` both be the identity function on collections.